### PR TITLE
Graph funding 1

### DIFF
--- a/contracts/NFT.sol
+++ b/contracts/NFT.sol
@@ -15,21 +15,30 @@ contract NFT is ERC721URIStorage, ReentrancyGuard, Ownable {
   Counters.Counter private _tokenIds;
 
   mapping(uint256 => uint256) private _donationBalance;
+  
+  mapping(uint256 => uint256[]) private _references;
 
+  event ReferencesUpdated(uint256 tokenId);
+  
   constructor() ERC721("SciGraph", "SCGP") {}
 
-  // TODO add the references
-  function createToken (string memory tokenURI) public returns(uint256) {
+  
+  function createToken (string memory tokenURI, uint256[] memory refs) public returns(uint256) {
     uint256 newTokenId = _tokenIds.current();
     _tokenIds.increment();
     _mint(msg.sender, newTokenId);
     _setTokenURI(newTokenId, tokenURI);
+    _createReferences(newTokenId, refs);
     return newTokenId;
   }
 
-  // TODO take a percentage of the donation to the protocol treasure
+  // receives a donation and tokenId
+  // updates _donationBalance[tokenId]
+  // TODO : take a cut for the treasury
+  // 
   function donate (uint256 tokenId) public payable nonReentrant {
     require(tokenId < _tokenIds.current(), "Token does not exist.");
+    // uint donation_liq = msg.value/100 ;
     _donationBalance[tokenId] = _donationBalance[tokenId].add(msg.value);
   }
 
@@ -41,6 +50,113 @@ contract NFT is ERC721URIStorage, ReentrancyGuard, Ownable {
     return _tokenIds.current();
   }
 
+// creates the list of references for tokenId in _references mapping 
+// verifies if the entries in the list are valid _tokenIds
+// 
+  function _createReferences (uint256 tokenId, uint256[] memory refs) private { 
+    uint i;
+    for (i=0 ; i < refs.length ; i++){
+      require( refs[i] < _tokenIds.current() , "_createReferences: Invalid tokenId in Reference entries" );
+    } 
+    
+    _references[tokenId] = refs;
+
+  }
+
+// returns a list of references of a tokenId
+// 
+function getReferences (uint256 tokenId) public view returns(uint256[] memory) {
+  require(tokenId >= 0 && tokenId < _tokenIds.current(), "_getReferences : enter a valid token Id");
+  return _references[tokenId];
+}
+
+
+
+// receives a tokenId and a list of references (refs)
+// adds refs entries to _references[tokenId]
+// only callable by token owner
+// 
+  function addReferences(uint256 tokenId, uint256[] memory refs) public {
+    require(ownerOf(tokenId) == msg.sender, "addReferences: Only owner of token can perform this task");
+    uint i;
+    for(i = 0 ; i < refs.length ; i++) {
+      require(refs[i] < _tokenIds.current(), "addReferences: Invalid tokenId in Reference entries" );
+      _references[tokenId].push(refs[i]);
+      }
+    emit ReferencesUpdated(tokenId);
+  }
+
+// receives a tokenId and a list of references (refs)
+// subtracts refs entries from _references[tokenId] (in case of common entries)
+// Note: 
+//  - in case of repeated entries in _references 
+// its only gonna subtract the quantity of repeated entries in refs
+//  - only callable by token owner
+// 
+  function subReferences(uint256 tokenId, uint256[] memory refs) public {
+    require(ownerOf(tokenId) == msg.sender, "subReferences: Only owner of token can perform this task" );
+    require(_references[tokenId].length > 0 , "subReferences: There are no references to be subtracted" );
+    uint256 i;
+    uint256 j;
+    for(i=0 ; i < refs.length ; i++){
+      for(j=0 ; j < _references[tokenId].length ; j++){
+        if (refs[i] == _references[tokenId][j]){
+          // moves last entry to position j and pops
+          _references[tokenId][j]=_references[tokenId][_references[tokenId].length-1];
+          _references[tokenId].pop();
+          break;
+        }
+      }
+      emit ReferencesUpdated(tokenId);
+    }
+  }
+
+// receives a tokenId
+// distributes part of funds to references
+// transfers the rest to token owner
+// 
+  function claimDonation (uint256 tokenId) public payable nonReentrant {
+    require(_donationBalance[tokenId] > 0, "claimDonation: There is no balance to be claimed" );
+    
+    address payable owner = payable( ownerOf(tokenId) );
+    uint256 owner_cut;
+    if(_references[tokenId].length >0 ){
+      
+      owner_cut = _fundRefs(tokenId);
+    }
+    else{
+
+      owner_cut = _donationBalance[tokenId];
+    }
+    
+    _donationBalance[tokenId] = 0 ;
+    // owner.transfer(owner_cut);
+    (bool success, ) = owner.call{value: owner_cut}("");
+    require(success, "claim donation: Transfer of funds failed");
+
+  }
+
+// distributes part of the funds in _donationBalance[tokenId] to the references
+// 
+  function _fundRefs (uint256 tokenId) private returns(uint256 owner_cut)  {
+
+    uint256 _owner_cut;
+    uint256 refs_cut;
+
+    _owner_cut = ( _donationBalance[tokenId] * 2 ) / 3;
+    refs_cut =  _donationBalance[tokenId] /3 ;
+    _owner_cut += ( _donationBalance[tokenId] - _owner_cut - refs_cut );
+    refs_cut = refs_cut / _references[tokenId].length ; 
+
+
+    uint256 i;
+    for(i=0 ; i<_references[tokenId].length ; i++){
+      _donationBalance[ _references[tokenId][i] ].add(refs_cut);
+    }
+
+    return _owner_cut;
+  }
+ 
   // claim donation
   // withdraw treasure?
   // opensea royalties?

--- a/test/sample-test.js
+++ b/test/sample-test.js
@@ -25,12 +25,12 @@ describe("Testing the NFT contract", function () {
     token_0 = await contract.createToken(token0Uri, []);
   });
 
-  it.skip("Test name and tokenUri", async function () {
+  it("Test name and tokenUri", async function () {
     expect(await contract.name()).to.equal("SciGraph");
     expect(await contract.tokenURI(0)).to.equal(token0Uri);
   });
 
-  it.skip("Test donate method", async function () {
+  it("Test donate method", async function () {
     // Parse the etherString representation of ether 
     // into a BigNumber instance of the amount of wei.
     const donationAmount = ethers.utils.parseEther("1");
@@ -39,7 +39,7 @@ describe("Testing the NFT contract", function () {
     // expect(await contract.tokenDonationBalance(0)).to.equal(donationAmount/100);
   });
 
-  it.skip("Test create/get references", async function () {
+  it("Test create/get references", async function () {
     let refs0 = await contract.getReferences(0);
     expect(refs0.length == 0);
     // 
@@ -64,7 +64,7 @@ describe("Testing the NFT contract", function () {
     await expect (contract.createToken(token0Uri, ref_3)).to.be.revertedWith("_createReferences: Invalid tokenId in Reference entries");
   });
 
-  it.skip("Test add references", async function (){
+  it("Test add references", async function (){
     // _tokenIds[1]
     await contract.createToken(token0Uri, []);
     // _tokenIds[2]

--- a/test/sample-test.js
+++ b/test/sample-test.js
@@ -40,37 +40,38 @@ describe("Testing the NFT contract", function () {
     await contract.connect(alice).donate(0, {value: donationAmount});
     let net_donation = donationAmount.sub(donationAmount.div(100));
     let balance = await contract.tokenDonationBalance(0);
-    expect(balance.eq(net_donation));
+    expect(balance).to.eq(net_donation);
     let treasury_bal = await contract.getTreasuryBalance();
-    expect(treasury_bal.eq(donationAmount.sub(net_donation)));
-    // testing donasions < 100
+    expect(treasury_bal).to.eq( donationAmount.sub(net_donation) );
+    // // testing donations < 100
     const smallDonation = 90;
     await contract.connect(alice).donate(0, {value: smallDonation});
     balance_dash = await contract.tokenDonationBalance(0);
-    // balance_dash should be balance + smallDonation
-    expect(balance_dash.eq(balance.add(smallDonation)));
-    // treasury_bal should be the same as above
-    expect(treasury_bal.eq(donationAmount.sub(net_donation)));
+    // // balance_dash should be balance + smallDonation
+    expect(balance_dash).to.eq( balance.add(smallDonation) );
+    // // treasury_bal should be the same as above
+    expect(treasury_bal).to.eq( donationAmount.sub(net_donation) );
   });
 
   it.skip("Test create/get references", async function () {
     let refs0 = await contract.getReferences(0);
-    expect(refs0.length == 0);
+    expect(refs0.length).to.eq(0);
     // 
     // creates _tokenIds[1]
     // tests references of _tokenIds[1]
     await contract.createToken(token0Uri, [0]);
     let refs1 = await contract.getReferences(1);
-    expect(refs1[0] == 0 && refs1.length == 1);
-    // 
-    // creates _tokenIds[2]
-    // tests refs
+    expect(refs1.length).to.eq(1);
+    expect(refs1[0]).to.eq(0);
+    // // 
+    // // creates _tokenIds[2]
+    // // tests refs
     let ref_2 = [0,1];
     await contract.createToken(token0Uri, ref_2);
     let refs2 = await contract.getReferences(2);
-    expect(refs2.length == ref_2.length);
+    expect(refs2.length).to.eq(ref_2.length);
     for(i=0 ; i<refs2.length ; i++) {
-      expect(refs2[i] == ref_2[i]); 
+      expect(refs2[i]).to.eq( ref_2[i] ); 
     }
     // creates _tokenIds[3] with wrong entry as ref
     // tests revert
@@ -87,9 +88,9 @@ describe("Testing the NFT contract", function () {
     let new_refs = [1,2];
     await contract.addReferences(0, new_refs);
     let refs0 =  await contract.getReferences(0);
-    expect(refs0.length == 2);
+    expect(refs0.length).to.eq(new_refs.length);
     for(i=0 ; i<refs0.length ; i++){
-      expect( refs0[i ]== new_refs[i] );
+      expect( refs0[i] ).to.eq( new_refs[i] );
     }
     let another_ref = [99];
     await expect(contract.addReferences(0, another_ref)).to.be.revertedWith("addReferences: Invalid tokenId in Reference entries");
@@ -97,46 +98,55 @@ describe("Testing the NFT contract", function () {
   });
 
   it.skip("Tests subtract references", async function () {
-    expect(contract.subReferences(0, [1])).to.be.revertedWith("subReferences: There are no references to be subtracted");
     
-    // _tokenIds[1]
+    await expect(contract.subReferences(0, [1])).to.be.revertedWith("subReferences: There are no references to be subtracted");
+        // _tokenIds[1]
     await contract.createToken(token0Uri, []);
-    // _tokenIds[2]
+    // // _tokenIds[2]
     await contract.createToken(token0Uri, []);
     await contract.addReferences(0,[1,2]);
     await expect(contract.connect(alice).subReferences(0,[1])).to.be.revertedWith("subReferences: Only owner of token can perform this task");
     await contract.subReferences(0, [1]);
-    expect(await contract.getReferences(0)[0] == 2);
+    let ref = await contract.getReferences(0);
+    expect(ref[0]).to.eq(2);
     await contract.subReferences(0, [2]);
-    expect(await contract.getReferences(0).length == 0);
+    ref = await contract.getReferences(0);
+    expect(ref.length).to.eq(0);
   });
 
   it("Tests claim donations", async function () {
     let owner_bal = await owner.getBalance();
     const donationAmount = ethers.utils.parseEther("1");
     await contract.connect(alice).donate(0, {value: donationAmount});
-    await contract.claimDonation(0);
+    await contract.connect(bob).claimDonation(0);
     let owner_bal_2 = await owner.getBalance();
-    expect ( owner_bal_2.eq( owner_bal.add( donationAmount)));
+    const net_donation = ( donationAmount.mul(99) ).div(100);
+    expect ( owner_bal_2).to.eq( owner_bal.add(  ( net_donation.mul(99) ).div(100)  ) );
+    
     await expect(contract.claimDonation(0)).to.be.revertedWith( "claimDonation: There is no balance to be claimed");
-    // _tokenIds[1]
+    // // _tokenIds[1]
     await contract.createToken(token0Uri, []);
-    // _tokenIds[2]
+    // // _tokenIds[2]
     await contract.createToken(token0Uri, []);
-    await contract.addReferences(0, [1,2]);
+    const refs = [1,2];
+    await contract.addReferences(0, refs);
 
     await contract.connect(alice).donate(0, {value: donationAmount});
     owner_bal = await owner.getBalance();
-    bob_bal = await bob.getBalance();
-    await contract.connect(bob).claimDonation(0);
+    let bob_bal = await bob.getBalance();
+    let tx_claim = await contract.connect(bob).claimDonation(0);
     owner_bal_2 = await owner.getBalance();
-    expect ( owner_bal_2.eq( owner_bal.add( ethers.BigNumber.from("653400000000000000")) ));
+    expect ( owner_bal_2 ).to.eq( owner_bal.add( ( ( ( net_donation.mul(99) ).div(100) ).mul(2) ).div(3) ) );
+    
     let token1_bal = await contract.tokenDonationBalance(1);
     let token2_bal = await contract.tokenDonationBalance(2);
-    expect ( token1_bal.eq( ethers.BigNumber.from("163350000000000000")) );
-    expect ( token2_bal.eq( ethers.BigNumber.from("163350000000000000") ) );
+    expect ( token1_bal ).to.eq( ( ( ( net_donation.mul(99) ).div(100) ).div(3) ).div(refs.length) ) ;
+    expect ( token2_bal ).to.eq( ( ( ( net_donation.mul(99) ).div(100) ).div(3) ).div(refs.length) ) ;
+    
     let bob_bal_2 = await bob.getBalance();
-    expect ( bob_bal_2.eq( bob_bal.add(ethers.BigNumber.from("9900000000000000") ) ) );
+    receipt = await tx_claim.wait();
+    const tx_gasPaid = receipt.gasUsed * receipt.effectiveGasPrice;
+    expect(bob_bal_2).to.eq( ( bob_bal.add( net_donation.div(100) ) ).sub(tx_gasPaid) );
   });
 
 });

--- a/test/sample-test.js
+++ b/test/sample-test.js
@@ -10,7 +10,8 @@ describe("Testing the NFT contract", function () {
   let bob;
   let ownerAddress;
   let aliceAddress;
-  let bobAddress;
+  let bobAddress
+  let token_0;
 
   const token0Uri = "https://protocol.ai/"
 
@@ -21,22 +22,100 @@ describe("Testing the NFT contract", function () {
     bobAddress = await bob.getAddress();
     contractFactory = await ethers.getContractFactory("NFT");
     contract = await contractFactory.deploy();
-    await contract.createToken(token0Uri);
+    token_0 = await contract.createToken(token0Uri, []);
   });
 
-  it("Test name and tokenUri", async function () {
+  it.skip("Test name and tokenUri", async function () {
     expect(await contract.name()).to.equal("SciGraph");
     expect(await contract.tokenURI(0)).to.equal(token0Uri);
   });
 
-  it("Test donate method", async function () {
+  it.skip("Test donate method", async function () {
     // Parse the etherString representation of ether 
     // into a BigNumber instance of the amount of wei.
     const donationAmount = ethers.utils.parseEther("1");
     expect(await contract.tokenDonationBalance(0)).to.equal(0);
     await contract.connect(alice).donate(0, {value: donationAmount});
-    expect(await contract.tokenDonationBalance(0)).to.equal(donationAmount);
+    // expect(await contract.tokenDonationBalance(0)).to.equal(donationAmount/100);
   });
 
-  
+  it.skip("Test create/get references", async function () {
+    let refs0 = await contract.getReferences(0);
+    expect(refs0.length == 0);
+    // 
+    // creates _tokenIds[1]
+    // tests references of _tokenIds[1]
+    await contract.createToken(token0Uri, [0]);
+    let refs1 = await contract.getReferences(1);
+    expect(refs1[0] == 0 && refs1.length == 1);
+    // 
+    // creates _tokenIds[2]
+    // tests refs
+    let ref_2 = [0,1];
+    await contract.createToken(token0Uri, ref_2);
+    let refs2 = await contract.getReferences(2);
+    expect(refs2.length == ref_2.length);
+    for(i=0 ; i<refs2.length ; i++) {
+      expect(refs2[i] == ref_2[i]); 
+    }
+    // creates _tokenIds[3] with wrong entry as ref
+    // tests revert
+    let ref_3 = [0,1,99];
+    await expect (contract.createToken(token0Uri, ref_3)).to.be.revertedWith("_createReferences: Invalid tokenId in Reference entries");
+  });
+
+  it.skip("Test add references", async function (){
+    // _tokenIds[1]
+    await contract.createToken(token0Uri, []);
+    // _tokenIds[2]
+    await contract.createToken(token0Uri, []);
+
+    let new_refs = [1,2];
+    await contract.addReferences(0, new_refs);
+    let refs0 =  await contract.getReferences(0);
+    expect(refs0.length == 2);
+    for(i=0 ; i<refs0.length ; i++){
+      expect( refs0[i ]== new_refs[i] );
+    }
+    let another_ref = [99];
+    await expect(contract.addReferences(0, another_ref)).to.be.revertedWith("addReferences: Invalid tokenId in Reference entries");
+    await expect(contract.connect(alice).addReferences(0,[1])).to.be.revertedWith("addReferences: Only owner of token can perform this task")
+  });
+
+  it.skip("Tests subtract references", async function () {
+    expect(contract.subReferences(0, [1])).to.be.revertedWith("subReferences: There are no references to be subtracted");
+    
+    // _tokenIds[1]
+    await contract.createToken(token0Uri, []);
+    // _tokenIds[2]
+    await contract.createToken(token0Uri, []);
+    await contract.addReferences(0,[1,2]);
+    await expect(contract.connect(alice).subReferences(0,[1])).to.be.revertedWith("subReferences: Only owner of token can perform this task");
+    await contract.subReferences(0, [1]);
+    expect(await contract.getReferences(0)[0] == 2);
+    await contract.subReferences(0, [2]);
+    expect(await contract.getReferences(0).length == 0);
+  });
+
+  it("Tests claim donations", async function () {
+    let owner_bal = await owner.getBalance();
+    const donationAmount = ethers.utils.parseEther("1");
+    await contract.connect(alice).donate(0, {value: donationAmount});
+    await contract.claimDonation(0);
+    expect (await owner.getBalance() == owner_bal + donationAmount);
+    await expect(contract.claimDonation(0)).to.be.revertedWith( "claimDonation: There is no balance to be claimed");
+    // _tokenIds[1]
+    await contract.createToken(token0Uri, []);
+    // _tokenIds[2]
+    await contract.createToken(token0Uri, []);
+    await contract.addReferences(0, [1,2]);
+
+    await contract.connect(alice).donate(0, {value: donationAmount});
+    owner_bal = await owner.getBalance();
+    await contract.claimDonation(0);
+    expect(await owner.getBalance() == owner_bal + 666666666666666600);
+    expect(await contract.tokenDonationBalance(1) == 166666666666666660);
+    expect(await contract.tokenDonationBalance(2) == 166666666666666660);
+  });
+
 });


### PR DESCRIPTION
Added references and claim methods to the nft contracts. Part of the funds received as donations by an nft is passed on to the references nfts, creating a funding graph.